### PR TITLE
feature lock hooks / use Print instead of Stream 

### DIFF
--- a/src/sfe_bus.h
+++ b/src/sfe_bus.h
@@ -187,66 +187,70 @@ namespace SparkFun_UBLOX_GNSS
     Stream *_serialPort;
   };
 
-  // The sfeStream device defines behavior for Serial diagnostic prints based around the Stream class.
+  // The sfePrint device defines behavior for Serial diagnostic prints based around the Stream class.
   // This is Arduino specific.
-  class SfeStream
+  class SfePrint
   {
   public:
-    SfeStream(void) { _serialPort = nullptr; }
+    SfePrint(void) { _outputPort = nullptr; }
 
-    void init(Stream &serialPort) { _serialPort = &serialPort; }
+    void init(Print &outputPort) { _outputPort = &outputPort; }
+    inline bool operator==(SfePrint const &other) const { return _outputPort == other._outputPort; }
+    inline bool operator!=(SfePrint const &other) const { return !(*this == other); }
+    
     void write(uint8_t c)
     {
-      if (_serialPort != nullptr)
-        _serialPort->write(c);
+      if (_outputPort != nullptr)
+        _outputPort->write(c);
     }
     void print(const char *c)
     {
-      if (_serialPort != nullptr)
-        _serialPort->print(c);
+      if (_outputPort != nullptr)
+        _outputPort->print(c);
     }
     void print(const __FlashStringHelper *c)
     {
-      if (_serialPort != nullptr)
-        _serialPort->print(c);
+      if (_outputPort != nullptr)
+        _outputPort->print(c);
     }
     void print(unsigned int c, int f)
     {
-      if (_serialPort != nullptr)
-        _serialPort->print(c, f);
+      if (_outputPort != nullptr)
+        _outputPort->print(c, f);
     }
     void print(uint16_t c)
     {
-      if (_serialPort != nullptr)
-        _serialPort->print(c);
+      if (_outputPort != nullptr)
+        _outputPort->print(c);
     }
     void println()
     {
-      if (_serialPort != nullptr)
-        _serialPort->println();
+      if (_outputPort != nullptr)
+        _outputPort->println();
     }
     void println(const char *c)
     {
-      if (_serialPort != nullptr)
-        _serialPort->println(c);
+      if (_outputPort != nullptr)
+        _outputPort->println(c);
     }
     void println(const __FlashStringHelper *c)
     {
-      if (_serialPort != nullptr)
-        _serialPort->println(c);
+      if (_outputPort != nullptr)
+        _outputPort->println(c);
     }
     void println(size_t c)
     {
-      if (_serialPort != nullptr)
-        _serialPort->println(c);
+      if (_outputPort != nullptr)
+        _outputPort->println(c);
     }
     void println(uint8_t c, int f)
     {
-      if (_serialPort != nullptr)
-        _serialPort->println(c, f);
+      if (_outputPort != nullptr)
+        _outputPort->println(c, f);
     }
-
-    Stream *_serialPort; // friend doesn't seem to work... Leave this public
+  
+  private: 
+    Print *_outputPort;
   };
 
 };

--- a/src/u-blox_GNSS.cpp
+++ b/src/u-blox_GNSS.cpp
@@ -918,7 +918,7 @@ bool DevUBLOXGNSS::isConnected(uint16_t maxWait)
 
 // Enable or disable the printing of sent/response HEX values.
 // Use this in conjunction with 'Transport Logging' from the Universal Reader Assistant to see what they're doing that we're not
-void DevUBLOXGNSS::enableDebugging(Stream &debugPort, bool printLimitedDebug)
+void DevUBLOXGNSS::enableDebugging(Print &debugPort, bool printLimitedDebug)
 {
   _debugSerial.init(debugPort); // Grab which port the user wants us to use for debugging
   if (printLimitedDebug == false)
@@ -1516,7 +1516,7 @@ void DevUBLOXGNSS::process(uint8_t incoming, ubxPacket *incomingUBX, uint8_t req
 
     // If user has assigned an output port then pipe the characters there,
     // but only if the port is different (otherwise we'll output each character twice!)
-    if (_outputPort._serialPort != _ubxOutputPort._serialPort)
+    if (_outputPort != _ubxOutputPort)
       _ubxOutputPort.write(incoming); // Echo this byte to the serial port
 
     // Finally, increment the frame counter
@@ -1577,7 +1577,7 @@ void DevUBLOXGNSS::process(uint8_t incoming, ubxPacket *incomingUBX, uint8_t req
           processNMEA(nmeaAddressField[i]); // Process the start character and address field
           // If user has assigned an output port then pipe the characters there,
           // but only if the port is different (otherwise we'll output each character twice!)
-          if (_outputPort._serialPort != _nmeaOutputPort._serialPort)
+          if (_outputPort != _nmeaOutputPort)
             _nmeaOutputPort.write(nmeaAddressField[i]); // Echo this byte to the serial port
         }
       }
@@ -1612,7 +1612,7 @@ void DevUBLOXGNSS::process(uint8_t incoming, ubxPacket *incomingUBX, uint8_t req
         processNMEA(incoming); // Pass incoming to processNMEA
         // If user has assigned an output port then pipe the characters there,
         // but only if the port is different (otherwise we'll output each character twice!)
-        if (_outputPort._serialPort != _nmeaOutputPort._serialPort)
+        if (_outputPort != _nmeaOutputPort)
           _nmeaOutputPort.write(incoming); // Echo this byte to the serial port
       }
     }
@@ -1712,7 +1712,7 @@ void DevUBLOXGNSS::process(uint8_t incoming, ubxPacket *incomingUBX, uint8_t req
 
     // If user has assigned an output port then pipe the characters there,
     // but only if the port is different (otherwise we'll output each character twice!)
-    if (_outputPort._serialPort != _rtcmOutputPort._serialPort)
+    if (_outputPort != _rtcmOutputPort)
       _rtcmOutputPort.write(incoming); // Echo this byte to the serial port
   }
 }
@@ -6622,24 +6622,24 @@ bool DevUBLOXGNSS::setSPIInput(uint8_t comSettings, uint8_t layer, uint16_t maxW
 }
 
 // Want to see the NMEA messages on the Serial port? Here's how
-void DevUBLOXGNSS::setNMEAOutputPort(Stream &outputPort)
+void DevUBLOXGNSS::setNMEAOutputPort(Print &outputPort)
 {
   _nmeaOutputPort.init(outputPort); // Store the port from user
 }
 
 // Want to see the RTCM messages on the Serial port? Here's how
-void DevUBLOXGNSS::setRTCMOutputPort(Stream &outputPort)
+void DevUBLOXGNSS::setRTCMOutputPort(Print &outputPort)
 {
   _rtcmOutputPort.init(outputPort); // Store the port from user
 }
 
 // Want to see the UBX messages on the Serial port? Here's how
-void DevUBLOXGNSS::setUBXOutputPort(Stream &outputPort)
+void DevUBLOXGNSS::setUBXOutputPort(Print &outputPort)
 {
   _ubxOutputPort.init(outputPort); // Store the port from user
 }
 
-void DevUBLOXGNSS::setOutputPort(Stream &outputPort)
+void DevUBLOXGNSS::setOutputPort(Print &outputPort)
 {
   _outputPort.init(outputPort); // Store the port from user
 }

--- a/src/u-blox_GNSS.cpp
+++ b/src/u-blox_GNSS.cpp
@@ -667,7 +667,7 @@ uint16_t DevUBLOXGNSS::available()
 // Not Applicable for SPI and Serial
 bool DevUBLOXGNSS::ping()
 {
-  if (!lock()) return 0;
+  if (!lock()) return false;
   bool ok = _sfeBus->ping();
   unlock();
   return ok;
@@ -1026,7 +1026,7 @@ bool DevUBLOXGNSS::checkUbloxInternal(ubxPacket *incomingUBX, uint8_t requestedC
   else if (_commType == COMM_TYPE_SPI)
     ok = (checkUbloxSpi(incomingUBX, requestedClass, requestedID));
   unlock();
-  return false;
+  return ok;
 }
 
 // Polls I2C for data, passing any new bytes to process()
@@ -5350,7 +5350,7 @@ bool DevUBLOXGNSS::pushRawData(uint8_t *dataBytes, size_t numDataBytes, bool cal
   if (numDataBytes == 0)
     return false; // Indicate to the user that there was no data to push
 
-  if (!lock()) return SFE_UBLOX_STATUS_FAIL;
+  if (!lock()) return false;
   bool ok = false;
   if (_commType == COMM_TYPE_SERIAL)
   {

--- a/src/u-blox_GNSS.cpp
+++ b/src/u-blox_GNSS.cpp
@@ -4168,6 +4168,7 @@ void DevUBLOXGNSS::addToChecksum(uint8_t incoming)
 sfe_ublox_status_e DevUBLOXGNSS::sendCommand(ubxPacket *outgoingUBX, uint16_t maxWait, bool expectACKonly)
 {
   sfe_ublox_status_e retVal = SFE_UBLOX_STATUS_SUCCESS;
+
   calcChecksum(outgoingUBX); // Sets checksum A and B bytes of the packet
 
 #ifndef SFE_UBLOX_REDUCED_PROG_MEM

--- a/src/u-blox_GNSS.h
+++ b/src/u-blox_GNSS.h
@@ -130,6 +130,8 @@ protected:
   // Flag to indicate if we are connected to UART1 or UART2
   // Needed to select the correct config items when enabling a periodic message
   bool _UART2 = false; // Default to UART1
+  // the lock / unlock functions can be used if you have multiple tasks writing to the bus. 
+  // the idea is that in a RTOS you override this class and the two functions in which you take and give a mutex.
   virtual bool lock(void) { return true; }
   virtual void unlock(void) { }
 public:
@@ -181,18 +183,18 @@ public:
 #if defined(USB_VID)                                                                   // Is the USB Vendor ID defined?
 #if (USB_VID == 0x1B4F)                                                                // Is this a SparkFun board?
 #if !defined(ARDUINO_SAMD51_THING_PLUS) & !defined(ARDUINO_SAMD51_MICROMOD)            // If it is not a SAMD51 Thing Plus or SAMD51 MicroMod
-  void enableDebugging(Stream &debugPort = SerialUSB, bool printLimitedDebug = false); // Given a port to print to, enable debug messages. Default to all, not limited.
+  void enableDebugging(Print &debugPort = SerialUSB, bool printLimitedDebug = false); // Given a port to print to, enable debug messages. Default to all, not limited.
 #else
-  void enableDebugging(Stream &debugPort = Serial, bool printLimitedDebug = false); // Given a port to print to, enable debug messages. Default to all, not limited.
+  void enableDebugging(Print &debugPort = Serial, bool printLimitedDebug = false); // Given a port to print to, enable debug messages. Default to all, not limited.
 #endif
 #else
-  void enableDebugging(Stream &debugPort = Serial, bool printLimitedDebug = false); // Given a port to print to, enable debug messages. Default to all, not limited.
+  void enableDebugging(Print &debugPort = Serial, bool printLimitedDebug = false); // Given a port to print to, enable debug messages. Default to all, not limited.
 #endif
 #else
-  void enableDebugging(Stream &debugPort = Serial, bool printLimitedDebug = false); // Given a port to print to, enable debug messages. Default to all, not limited.
+  void enableDebugging(Print &debugPort = Serial, bool printLimitedDebug = false); // Given a port to print to, enable debug messages. Default to all, not limited.
 #endif
 #else
-  void enableDebugging(Stream &debugPort = Serial, bool printLimitedDebug = false); // Given a port to print to, enable debug messages. Default to all, not limited.
+  void enableDebugging(Print &debugPort = Serial, bool printLimitedDebug = false); // Given a port to print to, enable debug messages. Default to all, not limited.
 #endif
 
   void disableDebugging(void);                       // Turn off debug statements
@@ -319,10 +321,10 @@ public:
   bool setUSBInput(uint8_t comSettings, uint8_t layer = VAL_LAYER_RAM_BBR, uint16_t maxWait = kUBLOXGNSSDefaultMaxWait);   // Configure USB port to output UBX, NMEA, RTCM3, SPARTN or a combination thereof
   bool setSPIInput(uint8_t comSettings, uint8_t layer = VAL_LAYER_RAM_BBR, uint16_t maxWait = kUBLOXGNSSDefaultMaxWait);   // Configure SPI port to output UBX, NMEA, RTCM3, SPARTN or a combination thereof
 
-  void setNMEAOutputPort(Stream &outputPort); // Sets the internal variable for the port to direct only NMEA characters to
-  void setRTCMOutputPort(Stream &outputPort); // Sets the internal variable for the port to direct only RTCM characters to
-  void setUBXOutputPort(Stream &outputPort);  // Sets the internal variable for the port to direct only UBX characters to
-  void setOutputPort(Stream &outputPort);     // Sets the internal variable for the port to direct ALL characters to
+  void setNMEAOutputPort(Print &outputPort); // Sets the internal variable for the port to direct only NMEA characters to
+  void setRTCMOutputPort(Print &outputPort); // Sets the internal variable for the port to direct only RTCM characters to
+  void setUBXOutputPort(Print &outputPort);  // Sets the internal variable for the port to direct only UBX characters to
+  void setOutputPort(Print &outputPort);     // Sets the internal variable for the port to direct ALL characters to
 
   // Reset to defaults
 
@@ -1352,11 +1354,11 @@ protected:
   // Variables
   SparkFun_UBLOX_GNSS::GNSSDeviceBus *_sfeBus;
 
-  SparkFun_UBLOX_GNSS::SfeStream _nmeaOutputPort; // The user can assign an output port to print NMEA sentences if they wish
-  SparkFun_UBLOX_GNSS::SfeStream _rtcmOutputPort; // The user can assign an output port to print RTCM sentences if they wish
-  SparkFun_UBLOX_GNSS::SfeStream _ubxOutputPort;  // The user can assign an output port to print UBX sentences if they wish
-  SparkFun_UBLOX_GNSS::SfeStream _outputPort;     // The user can assign an output port to print ALL characters to if they wish
-  SparkFun_UBLOX_GNSS::SfeStream _debugSerial;    // The stream to send debug messages to if enabled
+  SparkFun_UBLOX_GNSS::SfePrint _nmeaOutputPort; // The user can assign an output port to print NMEA sentences if they wish
+  SparkFun_UBLOX_GNSS::SfePrint _rtcmOutputPort; // The user can assign an output port to print RTCM sentences if they wish
+  SparkFun_UBLOX_GNSS::SfePrint _ubxOutputPort;  // The user can assign an output port to print UBX sentences if they wish
+  SparkFun_UBLOX_GNSS::SfePrint _outputPort;     // The user can assign an output port to print ALL characters to if they wish
+  SparkFun_UBLOX_GNSS::SfePrint _debugSerial;    // The stream to send debug messages to if enabled
   bool _printDebug = false;                       // Flag to print the serial commands we are sending to the Serial port for debug
   bool _printLimitedDebug = false;                // Flag to print limited debug messages. Useful for I2C debugging or high navigation rates
 

--- a/src/u-blox_GNSS.h
+++ b/src/u-blox_GNSS.h
@@ -108,7 +108,7 @@ protected:
   void setCommunicationBus(SparkFun_UBLOX_GNSS::GNSSDeviceBus &theBus);
   // For I2C, ping the _address
   // Not Applicable for SPI and Serial
-  uint16_t ping();
+  bool ping();
   // For Serial, return Serial.available()
   // For I2C, read registers 0xFD and 0xFE. Return bytes available as uint16_t
   // Not Applicable for SPI
@@ -130,6 +130,8 @@ protected:
   // Flag to indicate if we are connected to UART1 or UART2
   // Needed to select the correct config items when enabling a periodic message
   bool _UART2 = false; // Default to UART1
+  virtual bool lock(void) { return true; }
+  virtual void unlock(void) { }
 public:
   void connectedToUART2(bool connected = true) { _UART2 = connected; }
 


### PR DESCRIPTION
- add hooks to allow use in RTOS environment where multiple tasks may write to the interface. 
- use Print instead of Stream for all debug **output** ports (Arduino inherits Stream interface from Print interface)