### PR TITLE
Correct ZED-F9P, NEO-D9S_and_NEO-D9C Examples (fixType==4)

### DIFF
--- a/examples/NEO-D9S_and_NEO-D9C/Example2_LBand_Corrections_with_NEO-D9S/Example2_LBand_Corrections_with_NEO-D9S.ino
+++ b/examples/NEO-D9S_and_NEO-D9C/Example2_LBand_Corrections_with_NEO-D9S/Example2_LBand_Corrections_with_NEO-D9S.ino
@@ -108,7 +108,7 @@ void printPVTdata(UBX_NAV_PVT_data_t *ubxDataStruct)
     Serial.print(F(" (2D)"));
   else if (fixType == 3)
     Serial.print(F(" (3D)"));
-  else if (fixType == 3)
+  else if (fixType == 4)
     Serial.print(F(" (GNSS + Dead Reckoning)"));
   else if (fixType == 5)
     Serial.print(F(" (Time Only)"));

--- a/examples/NEO-D9S_and_NEO-D9C/Example3_LBand_Corrections_with_NEO-D9S_using_SPI/Example3_LBand_Corrections_with_NEO-D9S_using_SPI.ino
+++ b/examples/NEO-D9S_and_NEO-D9C/Example3_LBand_Corrections_with_NEO-D9S_using_SPI/Example3_LBand_Corrections_with_NEO-D9S_using_SPI.ino
@@ -100,7 +100,7 @@ void printPVTdata(UBX_NAV_PVT_data_t *ubxDataStruct)
     Serial.print(F(" (2D)"));
   else if (fixType == 3)
     Serial.print(F(" (3D)"));
-  else if (fixType == 3)
+  else if (fixType == 4)
     Serial.print(F(" (GNSS + Dead Reckoning)"));
   else if (fixType == 5)
     Serial.print(F(" (Time Only)"));

--- a/examples/NEO-D9S_and_NEO-D9C/Example5_QZSSL6_Corrections_with_NEO-D9C/Example5_QZSSL6_Corrections_with_NEO-D9C.ino
+++ b/examples/NEO-D9S_and_NEO-D9C/Example5_QZSSL6_Corrections_with_NEO-D9C/Example5_QZSSL6_Corrections_with_NEO-D9C.ino
@@ -126,7 +126,7 @@ void printPVTdata(UBX_NAV_PVT_data_t *ubxDataStruct)
     Serial.print(F(" (2D)"));
   else if (fixType == 3)
     Serial.print(F(" (3D)"));
-  else if (fixType == 3)
+  else if (fixType == 4)
     Serial.print(F(" (GNSS + Dead Reckoning)"));
   else if (fixType == 5)
     Serial.print(F(" (Time Only)"));

--- a/examples/NEO-D9S_and_NEO-D9C/Example6_PMP_with_L-Band_Keys_via_MQTT/Example6_PMP_with_L-Band_Keys_via_MQTT.ino
+++ b/examples/NEO-D9S_and_NEO-D9C/Example6_PMP_with_L-Band_Keys_via_MQTT/Example6_PMP_with_L-Band_Keys_via_MQTT.ino
@@ -132,7 +132,7 @@ void printPVTdata(UBX_NAV_PVT_data_t *ubxDataStruct)
     Serial.print(F(" (2D)"));
   else if (fixType == 3)
     Serial.print(F(" (3D)"));
-  else if (fixType == 3)
+  else if (fixType == 4)
     Serial.print(F(" (GNSS + Dead Reckoning)"));
   else if (fixType == 5)
     Serial.print(F(" (Time Only)"));

--- a/examples/NEO-D9S_and_NEO-D9C/Example7_LBand_Corrections_over_Serial/Example7_LBand_Corrections_over_Serial.ino
+++ b/examples/NEO-D9S_and_NEO-D9C/Example7_LBand_Corrections_over_Serial/Example7_LBand_Corrections_over_Serial.ino
@@ -97,7 +97,7 @@ void printPVTdata(UBX_NAV_PVT_data_t *ubxDataStruct)
     Serial.print(F(" (2D)"));
   else if (fixType == 3)
     Serial.print(F(" (3D)"));
-  else if (fixType == 3)
+  else if (fixType == 4)
     Serial.print(F(" (GNSS + Dead Reckoning)"));
   else if (fixType == 5)
     Serial.print(F(" (Time Only)"));

--- a/examples/NEO-D9S_and_NEO-D9C/Example8_LBand_SPARTN_Parsing/Example8_LBand_SPARTN_Parsing.ino
+++ b/examples/NEO-D9S_and_NEO-D9C/Example8_LBand_SPARTN_Parsing/Example8_LBand_SPARTN_Parsing.ino
@@ -126,7 +126,7 @@ void printPVTdata(UBX_NAV_PVT_data_t *ubxDataStruct)
     Serial.print(F(" (2D)"));
   else if (fixType == 3)
     Serial.print(F(" (3D)"));
-  else if (fixType == 3)
+  else if (fixType == 4)
     Serial.print(F(" (GNSS + Dead Reckoning)"));
   else if (fixType == 5)
     Serial.print(F(" (Time Only)"));

--- a/examples/ZED-F9P/Example17_NTRIPClient_With_GGA_Callback/Example17_NTRIPClient_With_GGA_Callback.ino
+++ b/examples/ZED-F9P/Example17_NTRIPClient_With_GGA_Callback/Example17_NTRIPClient_With_GGA_Callback.ino
@@ -115,7 +115,7 @@ void printPVTdata(UBX_NAV_PVT_data_t *ubxDataStruct)
     Serial.print(F(" (2D)"));
   else if (fixType == 3)
     Serial.print(F(" (3D)"));
-  else if (fixType == 3)
+  else if (fixType == 4)
     Serial.print(F(" (GNSS + Dead Reckoning)"));
   else if (fixType == 5)
     Serial.print(F(" (Time Only)"));

--- a/examples/ZED-F9P/Example17_NTRIPClient_With_GGA_Callback__Serial/Example17_NTRIPClient_With_GGA_Callback__Serial.ino
+++ b/examples/ZED-F9P/Example17_NTRIPClient_With_GGA_Callback__Serial/Example17_NTRIPClient_With_GGA_Callback__Serial.ino
@@ -120,7 +120,7 @@ void printPVTdata(UBX_NAV_PVT_data_t *ubxDataStruct)
     Serial.print(F(" (2D)"));
   else if (fixType == 3)
     Serial.print(F(" (3D)"));
-  else if (fixType == 3)
+  else if (fixType == 4)
     Serial.print(F(" (GNSS + Dead Reckoning)"));
   else if (fixType == 5)
     Serial.print(F(" (Time Only)"));

--- a/examples/ZED-F9P/Example18_PointPerfectClient/Example18_PointPerfectClient.ino
+++ b/examples/ZED-F9P/Example18_PointPerfectClient/Example18_PointPerfectClient.ino
@@ -87,7 +87,7 @@ void printPVTdata(UBX_NAV_PVT_data_t *ubxDataStruct)
     Serial.print(F(" (2D)"));
   else if (fixType == 3)
     Serial.print(F(" (3D)"));
-  else if (fixType == 3)
+  else if (fixType == 4)
     Serial.print(F(" (GNSS + Dead Reckoning)"));
   else if (fixType == 5)
     Serial.print(F(" (Time Only)"));


### PR DESCRIPTION
GNSS + Dead Reckoning is Fix Type 4, not Fix Type 3.  
See page 104 of https://content.u-blox.com/sites/default/files/documents/u-blox-F9-HPG-1.32_InterfaceDescription_UBX-22008968.pdf

Looks like "else if (fixType == 3)" was accidentally duplicated

This bug appears in the NEO-D9S_and_NEO-D9C and ZED-F9P Examples