### PR TITLE
Particle platform compatibility

### DIFF
--- a/src/sfe_bus.cpp
+++ b/src/sfe_bus.cpp
@@ -464,7 +464,10 @@ namespace SparkFun_UBLOX_GNSS
 
     if (length == 0)
       return 0;
-
+#ifdef PARTICLE
+    return _serialPort->readBytes((char *)data, length);
+#else
     return _serialPort->readBytes(data, length);
+#endif
   }
 }

--- a/src/sfe_bus.cpp
+++ b/src/sfe_bus.cpp
@@ -464,6 +464,7 @@ namespace SparkFun_UBLOX_GNSS
 
     if (length == 0)
       return 0;
+
 #ifdef PARTICLE
     return _serialPort->readBytes((char *)data, length);
 #else


### PR DESCRIPTION
I haven't done much platform porting so I'm not exactly sure the most correct way to fix this, but casting `data ` uint8_t* to char* resolves the Particle Workbench compiler error:
` invalid conversion from 'uint8_t*' {aka 'unsigned char*'} to 'char*' `

I would guess a next step would be to dig into DeviceOS serial handling but maybe someone can comment and save me the blind effort.

If this is an acceptable solution, or if it's safe to cast to char * for all platforms I'd like to see it merge into main so the library will drop into Particle Workbench without having to track changes.