### PR TITLE
Increase MAX_PAYLOAD_SIZE to 512 bytes

### DIFF
--- a/src/u-blox_external_typedefs.h
+++ b/src/u-blox_external_typedefs.h
@@ -254,7 +254,7 @@ struct sfe_ublox_ubx_logging_list_t
 
 #ifndef MAX_PAYLOAD_SIZE
 // v2.0: keep this for backwards-compatibility, but this is largely superseded by setPacketCfgPayloadSize
-#define MAX_PAYLOAD_SIZE 276 // We need >=250 bytes for getProtocolVersion on the NEO-F10N
+#define MAX_PAYLOAD_SIZE 512 // We need >=288 bytes for getModuleInfo on the ZED-X20P
 // #define MAX_PAYLOAD_SIZE 768 //Worst case: UBX_CFG_VALSET packet with 64 keyIDs each with 64 bit values
 #endif
 


### PR DESCRIPTION
**Changes:**
Update MAX_PAYLOAD_SIZE from 276 to 512 to support getModuleInfo() on the ZED-X20P GNSS module, which requires at least 288 bytes.

> *I verified this modification with an ESP32 Thing Plus and the ZED-X20P breakout.*
> ```
> SparkFun u-blox Example
> FWVER: 2.0
> Firmware: HPG
> PROTVER: 50.2
> MOD: ZED-X20P


**Resolves:**
When utilizing [Basics > Example8_GetModuleInfo](https://github.com/sparkfun/SparkFun_u-blox_GNSS_v3/blob/main/examples/Basics/Example8_GetModuleInfo/Example8_GetModuleInfo.ino) with the ZED-X20P, the library appears to run into a buffer overflow before it can detect the end of the response payload.

> Debug Message:
> ```
> Sending: CLS:MON ID:0x4 Len: 0x0 Payload:
> sendCommand: Waiting for No ACK response3
> checkUbloxI2C: 288 bytes available
> processUBX: counter hit maximum_payload_size + 6! activePacketBuffer: 0 maximum_payload_size: 276
> waitForNoACKResponse: TIMEOUT after 1100 msec. No packet received.
> ```