### PR TITLE
Mark NMEA/RTCM processing functions as weak to allow user overrides

### DIFF
--- a/src/u-blox_GNSS.cpp
+++ b/src/u-blox_GNSS.cpp
@@ -2477,7 +2477,7 @@ bool DevUBLOXGNSS::processThisNMEA()
 // This is the default or generic NMEA processor. We're only going to pipe the data to serial port so we can see it.
 // User could overwrite this function to pipe characters to nmea.process(c) of tinyGPS or MicroNMEA
 // Or user could pipe each character to a buffer, radio, etc.
-void DevUBLOXGNSS::processNMEA(char incoming)
+__attribute__((weak)) void DevUBLOXGNSS::processNMEA(char incoming)
 {
   (void)incoming;
 }
@@ -3197,7 +3197,7 @@ nmeaAutomaticFlags *DevUBLOXGNSS::getNMEAFlagsPtr()
 // Byte 2: 10-bits of length of this packet including the first two-ish header bytes, + 6.
 // byte 3 + 4 bits: Msg type 12 bits
 // Example: D3 00 7C 43 F0 ... / 0x7C = 124+6 = 130 bytes in this packet, 0x43F = Msg type 1087
-DevUBLOXGNSS::sfe_ublox_sentence_types_e DevUBLOXGNSS::processRTCMframe(uint8_t incoming, uint16_t *rtcmFrameCounter)
+__attribute__((weak)) DevUBLOXGNSS::sfe_ublox_sentence_types_e DevUBLOXGNSS::processRTCMframe(uint8_t incoming, uint16_t *rtcmFrameCounter)
 {
   static uint16_t rtcmLen = 0; // Static - length is retained between calls
 
@@ -3234,7 +3234,7 @@ DevUBLOXGNSS::sfe_ublox_sentence_types_e DevUBLOXGNSS::processRTCMframe(uint8_t 
 // This function is called for each byte of an RTCM frame
 // Ths user can overwrite this function and process the RTCM frame as they please
 // Bytes can be piped to Serial or other interface. The consumer could be a radio or the internet (Ntrip broadcaster)
-void DevUBLOXGNSS::processRTCM(uint8_t incoming)
+__attribute__((weak)) void DevUBLOXGNSS::processRTCM(uint8_t incoming)
 {
   (void)incoming;
 }

--- a/src/u-blox_GNSS.h
+++ b/src/u-blox_GNSS.h
@@ -234,9 +234,9 @@ public:
   // Process the incoming data
 
   void process(uint8_t incoming, ubxPacket *incomingUBX, uint8_t requestedClass, uint8_t requestedID);             // Processes NMEA and UBX binary sentences one byte at a time
-  void processNMEA(char incoming) __attribute__((weak));                                                           // Given a NMEA character, do something with it. User can overwrite if desired to use something like tinyGPS or MicroNMEA libraries
-  sfe_ublox_sentence_types_e processRTCMframe(uint8_t incoming, uint16_t *rtcmFrameCounter) __attribute__((weak)); // Monitor the incoming bytes for start and length bytes
-  void processRTCM(uint8_t incoming) __attribute__((weak));                                                        // Given rtcm byte, do something with it. User can overwrite if desired to pipe bytes to radio, internet, etc.
+  void processNMEA(char incoming);                                                                                 // Given a NMEA character, do something with it. User can overwrite if desired to use something like tinyGPS or MicroNMEA libraries
+  sfe_ublox_sentence_types_e processRTCMframe(uint8_t incoming, uint16_t *rtcmFrameCounter);                       // Monitor the incoming bytes for start and length bytes
+  void processRTCM(uint8_t incoming);                                                                              // Given rtcm byte, do something with it. User can overwrite if desired to pipe bytes to radio, internet, etc.
   void processUBX(uint8_t incoming, ubxPacket *incomingUBX, uint8_t requestedClass, uint8_t requestedID);          // Given a character, file it away into the uxb packet structure
   void processUBXpacket(ubxPacket *msg);                                                                           // Once a packet has been received and validated, identify this packet's class/id and update internal flags
   virtual void processLoggedUBX(ubxPacket *incomingUBX) {}                                                         // Process any UBX message with enableUBXlogging processMe set true


### PR DESCRIPTION
Moved GCC __attribute__((weak)) annotations from declarations in `src/u-blox_GNSS.h` to the function definitions in `src/u-blox_GNSS.cpp`.

Added weak linkage to default handlers so they can be overridden by user code: DevUBLOXGNSS::processNMEA(char incoming), DevUBLOXGNSS::processRTCMframe(uint8_t incoming, uint16_t *rtcmFrameCounter), DevUBLOXGNSS::processRTCM(uint8_t incoming).

Files modified: src/u-blox_GNSS.cpp, src/u-blox_GNSS.h.