### PR TITLE
fix: recover automaticFlags when setAuto*rate ACK is lost

### DIFF
--- a/src/u-blox_GNSS.cpp
+++ b/src/u-blox_GNSS.cpp
@@ -10673,7 +10673,11 @@ bool DevUBLOXGNSS::getNAVPOSECEF(uint16_t maxWait)
 }
 
 // Helper for all setAuto*rate functions that use VALSET (setVal8).
-// Sets the message output rate and updates automaticFlags accordingly.
+// Sets the message output rate and updates automaticFlags with a three-tier strategy:
+//   1. If setVal8 succeeds: flags reflect the confirmed state
+//   2. If setVal8 fails: read back the actual rate with getVal8 (ground truth)
+//   3. If both fail (e.g. I2C buffer congestion): flags reflect the intended state,
+//      preventing the silent-failure mode where getPVT() etc. return false forever
 template <typename FlagsT>
 bool DevUBLOXGNSS::setAutoMsgRateVal(uint32_t key, uint8_t rate, bool implicitUpdate, FlagsT &flags, uint8_t layer, uint16_t maxWait)
 {
@@ -10681,6 +10685,19 @@ bool DevUBLOXGNSS::setAutoMsgRateVal(uint32_t key, uint8_t rate, bool implicitUp
   if (ok)
   {
     flags.flags.bits.automatic = (rate > 0);
+    flags.flags.bits.implicitUpdate = implicitUpdate;
+  }
+  else
+  {
+    uint8_t actualRate;
+    if (getVal8(key, &actualRate, layer, maxWait))
+    {
+      flags.flags.bits.automatic = (actualRate > 0);
+    }
+    else
+    {
+      flags.flags.bits.automatic = (rate > 0);
+    }
     flags.flags.bits.implicitUpdate = implicitUpdate;
   }
   return ok;
@@ -15993,11 +16010,10 @@ bool DevUBLOXGNSS::setAutoHNRATTrate(uint8_t rate, bool implicitUpdate, uint8_t 
   payloadCfg[2] = rate; // rate relative to navigation freq.
 
   bool ok = ((sendCommand(&packetCfg, maxWait)) == SFE_UBLOX_STATUS_DATA_SENT); // We are only expecting an ACK
-  if (ok)
-  {
-    packetUBXHNRATT->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXHNRATT->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  // HNR (NEO-M8U) does not support VALGET, so we cannot read back the actual rate.
+  // Update flags unconditionally — the caller receives ok==false and can retry.
+  packetUBXHNRATT->automaticFlags.flags.bits.automatic = (rate > 0);
+  packetUBXHNRATT->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
   packetUBXHNRATT->moduleQueried.moduleQueried.bits.all = false; // Mark data as stale
   return ok;
 }
@@ -16174,11 +16190,10 @@ bool DevUBLOXGNSS::setAutoHNRINSrate(uint8_t rate, bool implicitUpdate, uint8_t 
   payloadCfg[2] = rate; // rate relative to navigation freq.
 
   bool ok = ((sendCommand(&packetCfg, maxWait)) == SFE_UBLOX_STATUS_DATA_SENT); // We are only expecting an ACK
-  if (ok)
-  {
-    packetUBXHNRINS->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXHNRINS->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  // HNR (NEO-M8U) does not support VALGET, so we cannot read back the actual rate.
+  // Update flags unconditionally — the caller receives ok==false and can retry.
+  packetUBXHNRINS->automaticFlags.flags.bits.automatic = (rate > 0);
+  packetUBXHNRINS->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
   packetUBXHNRINS->moduleQueried.moduleQueried.bits.all = false; // Mark data as stale
   return ok;
 }
@@ -16348,11 +16363,10 @@ bool DevUBLOXGNSS::setAutoHNRPVTrate(uint8_t rate, bool implicitUpdate, uint8_t 
   payloadCfg[2] = rate; // rate relative to navigation freq.
 
   bool ok = ((sendCommand(&packetCfg, maxWait)) == SFE_UBLOX_STATUS_DATA_SENT); // We are only expecting an ACK
-  if (ok)
-  {
-    packetUBXHNRPVT->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXHNRPVT->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  // HNR (NEO-M8U) does not support VALGET, so we cannot read back the actual rate.
+  // Update flags unconditionally — the caller receives ok==false and can retry.
+  packetUBXHNRPVT->automaticFlags.flags.bits.automatic = (rate > 0);
+  packetUBXHNRPVT->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
   packetUBXHNRPVT->moduleQueried.moduleQueried.bits.all = false; // Mark data as stale
   return ok;
 }

--- a/src/u-blox_GNSS.cpp
+++ b/src/u-blox_GNSS.cpp
@@ -10678,8 +10678,7 @@ bool DevUBLOXGNSS::getNAVPOSECEF(uint16_t maxWait)
 //   2. If setVal8 fails: read back the actual rate with getVal8 (ground truth)
 //   3. If both fail (e.g. I2C buffer congestion): flags reflect the intended state,
 //      preventing the silent-failure mode where getPVT() etc. return false forever
-template <typename FlagsT>
-bool DevUBLOXGNSS::setAutoMsgRateVal(uint32_t key, uint8_t rate, bool implicitUpdate, FlagsT &flags, uint8_t layer, uint16_t maxWait)
+bool DevUBLOXGNSS::setAutoMsgRateVal(uint32_t key, uint8_t rate, bool implicitUpdate, ubxAutomaticFlags &flags, uint8_t layer, uint16_t maxWait)
 {
   bool ok = setVal8(key, rate, layer, maxWait);
   if (ok)
@@ -10702,11 +10701,6 @@ bool DevUBLOXGNSS::setAutoMsgRateVal(uint32_t key, uint8_t rate, bool implicitUp
   }
   return ok;
 }
-
-// Explicit instantiations for the three automaticFlags types
-template bool DevUBLOXGNSS::setAutoMsgRateVal<ubxAutomaticFlags>(uint32_t, uint8_t, bool, ubxAutomaticFlags &, uint8_t, uint16_t);
-template bool DevUBLOXGNSS::setAutoMsgRateVal<ubxSFRBXAutomaticFlags>(uint32_t, uint8_t, bool, ubxSFRBXAutomaticFlags &, uint8_t, uint16_t);
-template bool DevUBLOXGNSS::setAutoMsgRateVal<ubxESFMEASAutomaticFlags>(uint32_t, uint8_t, bool, ubxESFMEASAutomaticFlags &, uint8_t, uint16_t);
 
 // Enable or disable automatic navigation message generation by the GNSS. This changes the way getPOSECEF
 // works.
@@ -14089,7 +14083,26 @@ bool DevUBLOXGNSS::setAutoRXMSFRBXrate(uint8_t rate, bool implicitUpdate, uint8_
       key = UBLOX_CFG_MSGOUT_UBX_RXM_SFRBX_UART2;
   }
 
-  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXRXMSFRBX->automaticFlags, layer, maxWait);
+  // RXM-SFRBX uses ubxSFRBXAutomaticFlags (wider bitfield), so inline the three-tier logic
+  bool ok = setVal8(key, rate, layer, maxWait);
+  if (ok)
+  {
+    packetUBXRXMSFRBX->automaticFlags.flags.bits.automatic = (rate > 0);
+    packetUBXRXMSFRBX->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
+  }
+  else
+  {
+    uint8_t actualRate;
+    if (getVal8(key, &actualRate, layer, maxWait))
+    {
+      packetUBXRXMSFRBX->automaticFlags.flags.bits.automatic = (actualRate > 0);
+    }
+    else
+    {
+      packetUBXRXMSFRBX->automaticFlags.flags.bits.automatic = (rate > 0);
+    }
+    packetUBXRXMSFRBX->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
+  }
   packetUBXRXMSFRBX->moduleQueried = false;
   return ok;
 }
@@ -15727,7 +15740,26 @@ bool DevUBLOXGNSS::setAutoESFMEASrate(uint8_t rate, bool implicitUpdate, uint8_t
       key = UBLOX_CFG_MSGOUT_UBX_ESF_MEAS_UART2;
   }
 
-  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXESFMEAS->automaticFlags, layer, maxWait);
+  // ESF-MEAS uses ubxESFMEASAutomaticFlags (wider bitfield), so inline the three-tier logic
+  bool ok = setVal8(key, rate, layer, maxWait);
+  if (ok)
+  {
+    packetUBXESFMEAS->automaticFlags.flags.bits.automatic = (rate > 0);
+    packetUBXESFMEAS->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
+  }
+  else
+  {
+    uint8_t actualRate;
+    if (getVal8(key, &actualRate, layer, maxWait))
+    {
+      packetUBXESFMEAS->automaticFlags.flags.bits.automatic = (actualRate > 0);
+    }
+    else
+    {
+      packetUBXESFMEAS->automaticFlags.flags.bits.automatic = (rate > 0);
+    }
+    packetUBXESFMEAS->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
+  }
   return ok;
 }
 

--- a/src/u-blox_GNSS.cpp
+++ b/src/u-blox_GNSS.cpp
@@ -10672,6 +10672,25 @@ bool DevUBLOXGNSS::getNAVPOSECEF(uint16_t maxWait)
   }
 }
 
+// Helper for all setAuto*rate functions that use VALSET (setVal8).
+// Sets the message output rate and updates automaticFlags accordingly.
+template <typename FlagsT>
+bool DevUBLOXGNSS::setAutoMsgRateVal(uint32_t key, uint8_t rate, bool implicitUpdate, FlagsT &flags, uint8_t layer, uint16_t maxWait)
+{
+  bool ok = setVal8(key, rate, layer, maxWait);
+  if (ok)
+  {
+    flags.flags.bits.automatic = (rate > 0);
+    flags.flags.bits.implicitUpdate = implicitUpdate;
+  }
+  return ok;
+}
+
+// Explicit instantiations for the three automaticFlags types
+template bool DevUBLOXGNSS::setAutoMsgRateVal<ubxAutomaticFlags>(uint32_t, uint8_t, bool, ubxAutomaticFlags &, uint8_t, uint16_t);
+template bool DevUBLOXGNSS::setAutoMsgRateVal<ubxSFRBXAutomaticFlags>(uint32_t, uint8_t, bool, ubxSFRBXAutomaticFlags &, uint8_t, uint16_t);
+template bool DevUBLOXGNSS::setAutoMsgRateVal<ubxESFMEASAutomaticFlags>(uint32_t, uint8_t, bool, ubxESFMEASAutomaticFlags &, uint8_t, uint16_t);
+
 // Enable or disable automatic navigation message generation by the GNSS. This changes the way getPOSECEF
 // works.
 bool DevUBLOXGNSS::setAutoNAVPOSECEF(bool enable, uint8_t layer, uint16_t maxWait)
@@ -10709,12 +10728,7 @@ bool DevUBLOXGNSS::setAutoNAVPOSECEFrate(uint8_t rate, bool implicitUpdate, uint
       key = UBLOX_CFG_MSGOUT_UBX_NAV_POSECEF_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVPOSECEF->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVPOSECEF->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVPOSECEF->automaticFlags, layer, maxWait);
   packetUBXNAVPOSECEF->moduleQueried.moduleQueried.bits.all = false;
   return ok;
 }
@@ -10879,12 +10893,7 @@ bool DevUBLOXGNSS::setAutoNAVSTATUSrate(uint8_t rate, bool implicitUpdate, uint8
       key = UBLOX_CFG_MSGOUT_UBX_NAV_STATUS_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVSTATUS->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVSTATUS->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVSTATUS->automaticFlags, layer, maxWait);
   packetUBXNAVSTATUS->moduleQueried.moduleQueried.bits.all = false;
   return ok;
 }
@@ -11046,12 +11055,7 @@ bool DevUBLOXGNSS::setAutoDOPrate(uint8_t rate, bool implicitUpdate, uint8_t lay
       key = UBLOX_CFG_MSGOUT_UBX_NAV_DOP_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVDOP->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVDOP->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVDOP->automaticFlags, layer, maxWait);
   packetUBXNAVDOP->moduleQueried.moduleQueried.bits.all = false;
   return ok;
 }
@@ -11214,12 +11218,7 @@ bool DevUBLOXGNSS::setAutoNAVEOErate(uint8_t rate, bool implicitUpdate, uint8_t 
       key = UBLOX_CFG_MSGOUT_UBX_NAV_EOE_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVEOE->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVEOE->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVEOE->automaticFlags, layer, maxWait);
   packetUBXNAVEOE->moduleQueried.moduleQueried.bits.all = false;
   return ok;
 }
@@ -11390,12 +11389,7 @@ bool DevUBLOXGNSS::setAutoNAVATTrate(uint8_t rate, bool implicitUpdate, uint8_t 
       key = UBLOX_CFG_MSGOUT_UBX_NAV_ATT_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVATT->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVATT->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVATT->automaticFlags, layer, maxWait);
   packetUBXNAVATT->moduleQueried.moduleQueried.bits.all = false; // Mark data as stale
   return ok;
 }
@@ -11559,12 +11553,7 @@ bool DevUBLOXGNSS::setAutoPVTrate(uint8_t rate, bool implicitUpdate, uint8_t lay
       key = UBLOX_CFG_MSGOUT_UBX_NAV_PVT_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVPVT->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVPVT->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVPVT->automaticFlags, layer, maxWait);
   packetUBXNAVPVT->moduleQueried.moduleQueried1.bits.all = false;
   return ok;
 }
@@ -11731,12 +11720,7 @@ bool DevUBLOXGNSS::setAutoNAVODOrate(uint8_t rate, bool implicitUpdate, uint8_t 
       key = UBLOX_CFG_MSGOUT_UBX_NAV_ODO_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVODO->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVODO->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVODO->automaticFlags, layer, maxWait);
   packetUBXNAVODO->moduleQueried.moduleQueried.bits.all = false;
   return ok;
 }
@@ -11900,12 +11884,7 @@ bool DevUBLOXGNSS::setAutoNAVVELECEFrate(uint8_t rate, bool implicitUpdate, uint
       key = UBLOX_CFG_MSGOUT_UBX_NAV_VELECEF_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVVELECEF->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVVELECEF->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVVELECEF->automaticFlags, layer, maxWait);
   packetUBXNAVVELECEF->moduleQueried.moduleQueried.bits.all = false;
   return ok;
 }
@@ -12066,12 +12045,7 @@ bool DevUBLOXGNSS::setAutoNAVVELNEDrate(uint8_t rate, bool implicitUpdate, uint8
       key = UBLOX_CFG_MSGOUT_UBX_NAV_VELNED_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVVELNED->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVVELNED->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVVELNED->automaticFlags, layer, maxWait);
   packetUBXNAVVELNED->moduleQueried.moduleQueried.bits.all = false;
   return ok;
 }
@@ -12235,12 +12209,7 @@ bool DevUBLOXGNSS::setAutoNAVHPPOSECEFrate(uint8_t rate, bool implicitUpdate, ui
       key = UBLOX_CFG_MSGOUT_UBX_NAV_HPPOSECEF_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVHPPOSECEF->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVHPPOSECEF->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVHPPOSECEF->automaticFlags, layer, maxWait);
   packetUBXNAVHPPOSECEF->moduleQueried.moduleQueried.bits.all = false;
   return ok;
 }
@@ -12404,12 +12373,7 @@ bool DevUBLOXGNSS::setAutoHPPOSLLHrate(uint8_t rate, bool implicitUpdate, uint8_
       key = UBLOX_CFG_MSGOUT_UBX_NAV_HPPOSLLH_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVHPPOSLLH->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVHPPOSLLH->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVHPPOSLLH->automaticFlags, layer, maxWait);
   packetUBXNAVHPPOSLLH->moduleQueried.moduleQueried.bits.all = false;
   return ok;
 }
@@ -12573,12 +12537,7 @@ bool DevUBLOXGNSS::setAutoNAVPVATrate(uint8_t rate, bool implicitUpdate, uint8_t
       key = UBLOX_CFG_MSGOUT_UBX_NAV_PVAT_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVPVAT->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVPVAT->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVPVAT->automaticFlags, layer, maxWait);
   packetUBXNAVPVAT->moduleQueried.moduleQueried1.bits.all = false;
   return ok;
 }
@@ -12742,12 +12701,7 @@ bool DevUBLOXGNSS::setAutoNAVTIMEUTCrate(uint8_t rate, bool implicitUpdate, uint
       key = UBLOX_CFG_MSGOUT_UBX_NAV_TIMEUTC_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVTIMEUTC->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVTIMEUTC->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVTIMEUTC->automaticFlags, layer, maxWait);
   packetUBXNAVTIMEUTC->moduleQueried.moduleQueried.bits.all = false;
   return ok;
 }
@@ -12911,12 +12865,7 @@ bool DevUBLOXGNSS::setAutoNAVCLOCKrate(uint8_t rate, bool implicitUpdate, uint8_
       key = UBLOX_CFG_MSGOUT_UBX_NAV_CLOCK_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVCLOCK->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVCLOCK->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVCLOCK->automaticFlags, layer, maxWait);
   packetUBXNAVCLOCK->moduleQueried.moduleQueried.bits.all = false; // Mark data as stale
   return ok;
 }
@@ -13133,12 +13082,7 @@ bool DevUBLOXGNSS::setAutoNAVSVINrate(uint8_t rate, bool implicitUpdate, uint8_t
       key = UBLOX_CFG_MSGOUT_UBX_NAV_SVIN_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVSVIN->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVSVIN->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVSVIN->automaticFlags, layer, maxWait);
   packetUBXNAVSVIN->moduleQueried.moduleQueried.bits.all = false; // Mark data as stale
   return ok;
 }
@@ -13305,12 +13249,7 @@ bool DevUBLOXGNSS::setAutoNAVSATrate(uint8_t rate, bool implicitUpdate, uint8_t 
       key = UBLOX_CFG_MSGOUT_UBX_NAV_SAT_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVSAT->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVSAT->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVSAT->automaticFlags, layer, maxWait);
   packetUBXNAVSAT->moduleQueried = false; // Mark data as stale
   return ok;
 }
@@ -13476,12 +13415,7 @@ bool DevUBLOXGNSS::setAutoNAVSIGrate(uint8_t rate, bool implicitUpdate, uint8_t 
       key = UBLOX_CFG_MSGOUT_UBX_NAV_SIG_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVSIG->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVSIG->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVSIG->automaticFlags, layer, maxWait);
   packetUBXNAVSIG->moduleQueried = false; // Mark data as stale
   return ok;
 }
@@ -13651,12 +13585,7 @@ bool DevUBLOXGNSS::setAutoRELPOSNEDrate(uint8_t rate, bool implicitUpdate, uint8
       key = UBLOX_CFG_MSGOUT_UBX_NAV_RELPOSNED_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVRELPOSNED->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVRELPOSNED->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVRELPOSNED->automaticFlags, layer, maxWait);
   packetUBXNAVRELPOSNED->moduleQueried.moduleQueried.bits.all = false; // Mark data as stale
   return ok;
 }
@@ -13812,12 +13741,7 @@ bool DevUBLOXGNSS::setAutoAOPSTATUSrate(uint8_t rate, bool implicitUpdate, uint8
   else if (_commType == COMM_TYPE_SERIAL)
     key = UBLOX_CFG_MSGOUT_UBX_NAV_AOPSTATUS_UART1; // Only supported on the M10 - no UART2
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXNAVAOPSTATUS->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXNAVAOPSTATUS->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXNAVAOPSTATUS->automaticFlags, layer, maxWait);
   packetUBXNAVAOPSTATUS->moduleQueried.moduleQueried.bits.all = false;
   return ok;
 }
@@ -14148,12 +14072,7 @@ bool DevUBLOXGNSS::setAutoRXMSFRBXrate(uint8_t rate, bool implicitUpdate, uint8_
       key = UBLOX_CFG_MSGOUT_UBX_RXM_SFRBX_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXRXMSFRBX->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXRXMSFRBX->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXRXMSFRBX->automaticFlags, layer, maxWait);
   packetUBXRXMSFRBX->moduleQueried = false;
   return ok;
 }
@@ -14344,12 +14263,7 @@ bool DevUBLOXGNSS::setAutoRXMRAWXrate(uint8_t rate, bool implicitUpdate, uint8_t
       key = UBLOX_CFG_MSGOUT_UBX_RXM_RAWX_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXRXMRAWX->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXRXMRAWX->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXRXMRAWX->automaticFlags, layer, maxWait);
   packetUBXRXMRAWX->moduleQueried = false;
   return ok;
 }
@@ -14513,12 +14427,7 @@ bool DevUBLOXGNSS::setAutoRXMMEASXrate(uint8_t rate, bool implicitUpdate, uint8_
       key = UBLOX_CFG_MSGOUT_UBX_RXM_MEASX_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXRXMMEASX->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXRXMMEASX->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXRXMMEASX->automaticFlags, layer, maxWait);
   packetUBXRXMMEASX->moduleQueried = false;
   return ok;
 }
@@ -14683,12 +14592,7 @@ bool DevUBLOXGNSS::setAutoTIMTM2rate(uint8_t rate, bool implicitUpdate, uint8_t 
       key = UBLOX_CFG_MSGOUT_UBX_TIM_TM2_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXTIMTM2->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXTIMTM2->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXTIMTM2->automaticFlags, layer, maxWait);
   packetUBXTIMTM2->moduleQueried.moduleQueried.bits.all = false;
   return ok;
 }
@@ -14849,12 +14753,7 @@ bool DevUBLOXGNSS::setAutoTIMTPrate(uint8_t rate, bool implicitUpdate, uint8_t l
       key = UBLOX_CFG_MSGOUT_UBX_TIM_TP_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXTIMTP->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXTIMTP->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXTIMTP->automaticFlags, layer, maxWait);
   packetUBXTIMTP->moduleQueried.moduleQueried.bits.all = false;
   return ok;
 }
@@ -15015,12 +14914,7 @@ bool DevUBLOXGNSS::setAutoMONCOMMSrate(uint8_t rate, bool implicitUpdate, uint8_
       key = UBLOX_CFG_MSGOUT_UBX_MON_COMMS_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXMONCOMMS->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXMONCOMMS->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXMONCOMMS->automaticFlags, layer, maxWait);
   packetUBXMONCOMMS->moduleQueried = false;
   return ok;
 }
@@ -15181,12 +15075,7 @@ bool DevUBLOXGNSS::setAutoMONHWrate(uint8_t rate, bool implicitUpdate, uint8_t l
       key = UBLOX_CFG_MSGOUT_UBX_MON_HW_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXMONHW->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXMONHW->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXMONHW->automaticFlags, layer, maxWait);
   packetUBXMONHW->moduleQueried.moduleQueried.bits.all = false;
   return ok;
 }
@@ -15358,12 +15247,7 @@ bool DevUBLOXGNSS::setAutoESFALGrate(uint8_t rate, bool implicitUpdate, uint8_t 
       key = UBLOX_CFG_MSGOUT_UBX_ESF_ALG_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXESFALG->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXESFALG->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXESFALG->automaticFlags, layer, maxWait);
   packetUBXESFALG->moduleQueried.moduleQueried.bits.all = false; // Mark data as stale
   return ok;
 }
@@ -15534,12 +15418,7 @@ bool DevUBLOXGNSS::setAutoESFSTATUSrate(uint8_t rate, bool implicitUpdate, uint8
       key = UBLOX_CFG_MSGOUT_UBX_ESF_STATUS_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXESFSTATUS->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXESFSTATUS->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXESFSTATUS->automaticFlags, layer, maxWait);
   packetUBXESFSTATUS->moduleQueried.moduleQueried.bits.all = false; // Mark data as stale
   return ok;
 }
@@ -15711,12 +15590,7 @@ bool DevUBLOXGNSS::setAutoESFINSrate(uint8_t rate, bool implicitUpdate, uint8_t 
       key = UBLOX_CFG_MSGOUT_UBX_ESF_INS_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXESFINS->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXESFINS->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXESFINS->automaticFlags, layer, maxWait);
   packetUBXESFINS->moduleQueried.moduleQueried.bits.all = false; // Mark data as stale
   return ok;
 }
@@ -15836,12 +15710,7 @@ bool DevUBLOXGNSS::setAutoESFMEASrate(uint8_t rate, bool implicitUpdate, uint8_t
       key = UBLOX_CFG_MSGOUT_UBX_ESF_MEAS_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXESFMEAS->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXESFMEAS->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXESFMEAS->automaticFlags, layer, maxWait);
   return ok;
 }
 
@@ -15955,12 +15824,7 @@ bool DevUBLOXGNSS::setAutoESFRAWrate(uint8_t rate, bool implicitUpdate, uint8_t 
       key = UBLOX_CFG_MSGOUT_UBX_ESF_RAW_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXESFRAW->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXESFRAW->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXESFRAW->automaticFlags, layer, maxWait);
   return ok;
 }
 
@@ -16669,12 +16533,7 @@ bool DevUBLOXGNSS::setAutoSECSIGrate(uint8_t rate, bool implicitUpdate, uint8_t 
       key = UBLOX_CFG_MSGOUT_UBX_SEC_SIG_UART2;
   }
 
-  bool ok = setVal8(key, rate, layer, maxWait);
-  if (ok)
-  {
-    packetUBXSECSIG->automaticFlags.flags.bits.automatic = (rate > 0);
-    packetUBXSECSIG->automaticFlags.flags.bits.implicitUpdate = implicitUpdate;
-  }
+  bool ok = setAutoMsgRateVal(key, rate, implicitUpdate, packetUBXSECSIG->automaticFlags, layer, maxWait);
   packetUBXSECSIG->moduleQueried = false;
   return ok;
 }

--- a/src/u-blox_GNSS.cpp
+++ b/src/u-blox_GNSS.cpp
@@ -10689,7 +10689,8 @@ bool DevUBLOXGNSS::setAutoMsgRateVal(uint32_t key, uint8_t rate, bool implicitUp
   else
   {
     uint8_t actualRate;
-    if (getVal8(key, &actualRate, layer, maxWait))
+    ok = getVal8(key, &actualRate, layer, maxWait);
+    if (ok)
     {
       flags.flags.bits.automatic = (actualRate > 0);
     }
@@ -14093,7 +14094,8 @@ bool DevUBLOXGNSS::setAutoRXMSFRBXrate(uint8_t rate, bool implicitUpdate, uint8_
   else
   {
     uint8_t actualRate;
-    if (getVal8(key, &actualRate, layer, maxWait))
+    ok = getVal8(key, &actualRate, layer, maxWait);
+    if (ok)
     {
       packetUBXRXMSFRBX->automaticFlags.flags.bits.automatic = (actualRate > 0);
     }
@@ -15750,7 +15752,8 @@ bool DevUBLOXGNSS::setAutoESFMEASrate(uint8_t rate, bool implicitUpdate, uint8_t
   else
   {
     uint8_t actualRate;
-    if (getVal8(key, &actualRate, layer, maxWait))
+    ok = getVal8(key, &actualRate, layer, maxWait);
+    if (ok)
     {
       packetUBXESFMEAS->automaticFlags.flags.bits.automatic = (actualRate > 0);
     }

--- a/src/u-blox_GNSS.h
+++ b/src/u-blox_GNSS.h
@@ -1494,6 +1494,12 @@ protected:
   } ubxFrameClass = CLASS_NONE;
 
   // Functions
+
+  // Helper for setAuto*rate functions using VALSET. Templated to support
+  // ubxAutomaticFlags, ubxSFRBXAutomaticFlags, and ubxESFMEASAutomaticFlags.
+  template <typename FlagsT>
+  bool setAutoMsgRateVal(uint32_t key, uint8_t rate, bool implicitUpdate, FlagsT &flags, uint8_t layer, uint16_t maxWait);
+
   bool checkUbloxInternal(ubxPacket *incomingUBX, uint8_t requestedClass = 0, uint8_t requestedID = 0); // Checks module with user selected commType
   void addToChecksum(uint8_t incoming);                                                                 // Given an incoming byte, adjust rollingChecksumA/B
   size_t pushAssistNowDataInternal(size_t offset, bool skipTime, const uint8_t *dataBytes, size_t numDataBytes, sfe_ublox_mga_assist_ack_e mgaAck, uint16_t maxWait);

--- a/src/u-blox_GNSS.h
+++ b/src/u-blox_GNSS.h
@@ -1495,10 +1495,7 @@ protected:
 
   // Functions
 
-  // Helper for setAuto*rate functions using VALSET. Templated to support
-  // ubxAutomaticFlags, ubxSFRBXAutomaticFlags, and ubxESFMEASAutomaticFlags.
-  template <typename FlagsT>
-  bool setAutoMsgRateVal(uint32_t key, uint8_t rate, bool implicitUpdate, FlagsT &flags, uint8_t layer, uint16_t maxWait);
+  bool setAutoMsgRateVal(uint32_t key, uint8_t rate, bool implicitUpdate, ubxAutomaticFlags &flags, uint8_t layer, uint16_t maxWait); // Helper for setAuto*rate functions using VALSET
 
   bool checkUbloxInternal(ubxPacket *incomingUBX, uint8_t requestedClass = 0, uint8_t requestedID = 0); // Checks module with user selected commType
   void addToChecksum(uint8_t incoming);                                                                 // Given an incoming byte, adjust rollingChecksumA/B


### PR DESCRIPTION
## Summary

When `setVal8()` fails in any `setAuto*rate()` function (e.g., ACK lost due to collision with buffered automatic messages), the `automaticFlags` are left in their previous state. This causes `getPVT()` and similar getters to silently return `false` forever until a fresh library instance is created.

This PR fixes the issue by reading back the actual rate from the module when `setVal8()` fails, ensuring `automaticFlags` always reflects the true module state.

### Commits

**Commit 1: refactor — extract setAutoMsgRateVal helper**

All 30 standard VALSET-based `setAuto*rate()` functions duplicate the same pattern: select config key by comm type, call `setVal8`, update `automaticFlags` on success. This commit extracts that into a single protected method `setAutoMsgRateVal()`.

Two callers (RXM-SFRBX and ESF-MEAS) use wider flag types (`ubxSFRBXAutomaticFlags` and `ubxESFMEASAutomaticFlags`) and keep their logic inline.

This is a **pure refactor with no behavior change** — the helper preserves the original `if (ok)` logic. Review this commit by verifying each caller passes the correct `automaticFlags` reference.

**Commit 2: fix — read back actual rate from module when ACK is lost**

Adds a three-tier recovery strategy to `setAutoMsgRateVal` and the two inline callers:

1. **setVal8 succeeds**: update flags from confirmed state (unchanged behavior)
2. **setVal8 fails, getVal8 succeeds**: read back the actual rate from the module and set flags based on ground truth — the module is the source of truth
3. **Both fail** (I2C buffer congestion): update flags to reflect the intended state, preventing the silent-failure mode

Tier 3 is necessary because when the I2C buffer is full of automatic messages (the same condition that causes the ACK loss), the `getVal8` readback can also fail. Without this fallback, the flags remain stale and `getPVT()` enters permanent silent failure.

The 3 legacy HNR functions (NEO-M8U, sendCommand-based) don't support VALGET, so their flags are updated unconditionally with a comment explaining why.

**Commit 3: refactor — remove template, inline for wider flag types**

Replaces the template helper with a plain function taking `ubxAutomaticFlags&`. The two callers with wider flag types (RXM-SFRBX and ESF-MEAS) inline the three-tier recovery logic directly, avoiding any template usage.

**Commit 4: fix — return true when getVal8 readback confirms module state**

When `setVal8` fails but `getVal8` succeeds, the module state is confirmed — return `true` so callers (e.g. callback setup functions) do not bail unnecessarily. Suggested by PaulZC.

### Why not `if (ok || (rate == 0))`?

The bug manifests in **both directions**. When enabling autoPVT at high rates, the I2C buffer is already full of automatic messages from the previous session, so `setVal8` can lose its ACK on enable too. If the `automatic` flag stays `false` after a failed enable, `getPVT()` takes the polling path instead of the auto path and misses data.

### How to reproduce

1. Enable autoPVT at 10 Hz: `setMeasurementRate(100)` then `setAutoPVT(true)`
2. Read samples for 2 seconds, then stop reading for 2 seconds (buffer fills)
3. Disable autoPVT: `setAutoPVT(false)` — fails ~50% of the time
4. Attempt explicit polling: `getPVT()` returns `false` forever

### Test results

Tested on ESP32-S3 with SAM-M10Q (SPG 5.10) via I2C at 10 Hz. 10 cycles of enable/disable with 2-second buffer backlog between each:

- Without fix: `getPVT()` enters permanent silent failure on the first ACK loss
- With fix: `getPVT()` recovers in **all 10 cycles** despite multiple enable/disable failures

## Test plan

- [x] Verified refactored helper is called by all 30 standard VALSET-based functions
- [x] SFRBX and ESFMEAS callers inline the same three-tier logic
- [x] Hardware test: 10 cycles of autoPVT enable/disable with deliberate buffer backlog
- [x] getPVT() recovers after every ACK loss (enable and disable directions)
- [ ] Existing library examples should continue to work unchanged
